### PR TITLE
Remove console.log from index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
 const owo = require('./owo.js')
-console.log(typeof owo.owo)
 module.exports = owo.owo


### PR DESCRIPTION
Should prevent "function" from being printed every time the module is imported.